### PR TITLE
Upgrade QuickCV to .NET Framework 4.8

### DIFF
--- a/QuickCV/App.config
+++ b/QuickCV/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
 </configuration>

--- a/QuickCV/QuickCV.csproj
+++ b/QuickCV/QuickCV.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>QuickCV</RootNamespace>
     <AssemblyName>QuickCV</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>3e162c4a</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/QuickCV/packages.config
+++ b/QuickCV/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenCvSharp3-AnyCPU" version="4.0.0.20181129" targetFramework="net45" />
-  <package id="OpenCvSharp4" version="4.0.0.20190108" targetFramework="net45" />
-  <package id="YamlDotNet" version="5.3.0" targetFramework="net45" />
+  <package id="OpenCvSharp3-AnyCPU" version="4.0.0.20181129" targetFramework="net48" />
+  <package id="OpenCvSharp4" version="4.0.0.20190108" targetFramework="net48" />
+  <package id="YamlDotNet" version="5.3.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
## Summary
- upgrade project to target .NET Framework 4.8
- update configuration files and package references for net48

## Testing
- `xbuild QuickCV.sln` *(fails: missing OpenCvSharp3-AnyCPU package)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b0f7808c832cbbf3fe92e60c019e